### PR TITLE
Change `computeAddress` Visibility to `internal`

### DIFF
--- a/src/SafeSingletonDeployer.sol
+++ b/src/SafeSingletonDeployer.sol
@@ -11,11 +11,11 @@ library SafeSingletonDeployer {
     address constant SAFE_SINGLETON_FACTORY = 0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7;
     VmSafe private constant VM = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    function computeAddress(bytes memory creationCode, bytes32 salt) public pure returns (address) {
+    function computeAddress(bytes memory creationCode, bytes32 salt) internal pure returns (address) {
         return computeAddress(creationCode, "", salt);
     }
 
-    function computeAddress(bytes memory creationCode, bytes memory args, bytes32 salt) public pure returns (address) {
+    function computeAddress(bytes memory creationCode, bytes memory args, bytes32 salt) internal pure returns (address) {
         return VM.computeCreate2Address({
             salt: salt,
             initCodeHash: _hashInitCode(creationCode, args),


### PR DESCRIPTION
This PR changes the visibility of the `computeAddress` library functions to be `internal`. Library functions that are `public` generate code to call to an external library contract.

This causes some inconveniences, for example uses of `computeAddress` with `forge script` to potentially broadcast a transaction to deploy the `SafeSingletonDeployer` library (even if it isn't actually needed).